### PR TITLE
feat: add list_allowed_directories tool

### DIFF
--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -42,6 +42,11 @@ type PathValidator interface {
 	ValidatePath(requestedPath string) (string, error)
 }
 
+// AllowedDirectoriesProvider defines operations for listing allowed directories
+type AllowedDirectoriesProvider interface {
+	ListAllowedDirectories() []string
+}
+
 // FileContent represents the content of a file with its path
 type FileContent struct {
 	Path    string `json:"path"`

--- a/internal/tools/utils.go
+++ b/internal/tools/utils.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -56,5 +55,7 @@ func ValidatePath(requestedPath string, allowedDirectories []string) (string, er
 		}
 	}
 
-	return "", os.ErrPermission
+	// Create a formatted list of allowed directories for the error message
+	allowedDirsStr := strings.Join(allowedDirectories, ", ")
+	return "", fmt.Errorf("path not allowed: %s. Allowed directories: [%s]", requestedPath, allowedDirsStr)
 }

--- a/internal/tools/utils_test.go
+++ b/internal/tools/utils_test.go
@@ -4,6 +4,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExpandHome(t *testing.T) {
@@ -49,6 +51,64 @@ func TestExpandHome(t *testing.T) {
 			got := ExpandHome(tt.path)
 			if got != tt.wantPath {
 				t.Errorf("ExpandHome() = %v, want %v", got, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	// Define test allowed directories
+	allowedDirs := []string{"/tmp", "/var", "/home/user"}
+
+	tests := []struct {
+		name        string
+		path        string
+		expectError bool
+		errorCheck  func(t *testing.T, err error)
+	}{
+		{
+			name:        "Valid path inside allowed directory",
+			path:        "/tmp/file.txt",
+			expectError: false,
+		},
+		{
+			name:        "Path outside allowed directories",
+			path:        "/etc/hosts",
+			expectError: true,
+			errorCheck: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				// Check that the error message contains all allowed directories
+				errMsg := err.Error()
+				assert.Contains(t, errMsg, "path not allowed: /etc/hosts")
+				for _, dir := range allowedDirs {
+					assert.Contains(t, errMsg, dir)
+				}
+			},
+		},
+		{
+			name:        "Path with invalid characters",
+			path:        string([]byte{0}) + "/tmp/file.txt",
+			expectError: true,
+			errorCheck: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid characters")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			validPath, err := ValidatePath(tc.path, allowedDirs)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, validPath)
+				if tc.errorCheck != nil {
+					tc.errorCheck(t, err)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotEmpty(t, validPath)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a new tool to list the allowed directories that can be accessed by the filesystem tools. This provides transparency about which directories can be manipulated using the filesystem tools. Changes: Added a new AllowedDirectoriesProvider interface, updated ServiceProvider to implement the interface, added a new list_allowed_directories tool, and added tests for the new functionality. All tests and linting checks are passing.