### PR TITLE
docs: improve tool descriptions with better formatting

### DIFF
--- a/internal/tools/registration.go
+++ b/internal/tools/registration.go
@@ -51,10 +51,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register read_file tool
 	readFileTool := mcp.NewTool("read_file",
-		mcp.WithDescription("Read the complete contents of a file from the file system. "+
-			"Handles various text encodings and provides detailed error messages "+
-			"if the file cannot be read. Use this tool when you need to examine "+
-			"the contents of a single file. Only works within allowed directories."),
+		mcp.WithDescription(`description: Read the complete contents of a file from the file system. This tool safely reads files only within allowed directories and handles various encodings. Returns the full text content of the specified file.
+demo_commands: [{"path": "/path/to/file.txt"}, {"path": "./relative/path/document.md"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to read"),
@@ -66,11 +64,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register read_multiple_files tool
 	readMultipleFilesTool := mcp.NewTool("read_multiple_files",
-		mcp.WithDescription("Read the contents of multiple files simultaneously. This is more "+
-			"efficient than reading files one by one when you need to analyze "+
-			"or compare multiple files. Each file's content is returned with its "+
-			"path as a reference. Failed reads for individual files won't stop "+
-			"the entire operation. Only works within allowed directories."),
+		mcp.WithDescription(`description: Read multiple files in a single operation. This is more efficient than making separate read requests when analyzing related files. Provide a JSON array of file paths, and receive a JSON object mapping each path to its content.
+demo_commands: [{"paths": "[\"./config.json\", \"./settings.yaml\", \"./data/sample.txt\"]"}]`),
 		mcp.WithString("paths",
 			mcp.Required(),
 			mcp.Description("JSON array of paths to the files to read"),
@@ -82,9 +77,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register write_file tool
 	writeFileTool := mcp.NewTool("write_file",
-		mcp.WithDescription("Write content to a file on the file system. Creates the file if it "+
-			"doesn't exist, or overwrites it if it does. Can optionally append to "+
-			"existing files instead of overwriting. Only works within allowed directories."),
+		mcp.WithDescription(`description: Write content to a file, creating it if it doesn't exist or overwriting/appending if it does. Use the append flag to add content to the end of an existing file rather than replacing its contents.
+demo_commands: [{"path": "./new_file.txt", "content": "Hello, world!"}, {"path": "./logs.txt", "content": "New log entry", "append": true}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to write"),
@@ -103,10 +97,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register edit_file tool
 	editFileTool := mcp.NewTool("edit_file",
-		mcp.WithDescription("Edit a specific portion of a file by replacing lines between "+
-			"start_line and end_line with the provided content. This is useful "+
-			"for making targeted changes to files without rewriting the entire "+
-			"file. Only works within allowed directories."),
+		mcp.WithDescription(`description: Edit a specific portion of a file by replacing lines between start_line and end_line with new content. This is useful for making precise changes without rewriting the entire file. Line numbers are 1-indexed.
+demo_commands: [{"path": "./config.json", "content": "  \"debug\": true,", "start_line": 5, "end_line": 5}, {"path": "./src/main.go", "content": "// TODO: Implement error handling", "start_line": 42, "end_line": 45}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to edit"),
@@ -130,10 +122,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register list_directory tool
 	listDirectoryTool := mcp.NewTool("list_directory",
-		mcp.WithDescription("List the contents of a directory, showing files and subdirectories "+
-			"with their metadata. This is useful for exploring the file system "+
-			"and understanding the structure of directories. Only works within "+
-			"allowed directories."),
+		mcp.WithDescription(`description: List all files and subdirectories in a specified directory, including metadata like file size, modification time, and file type. Returns a JSON array of entry objects.
+demo_commands: [{"path": "."}, {"path": "./src"}, {"path": "/allowed/directory/path"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to list"),
@@ -145,9 +135,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register create_directory tool
 	createDirectoryTool := mcp.NewTool("create_directory",
-		mcp.WithDescription("Create a new directory at the specified path. Creates parent "+
-			"directories as needed if they don't exist. Only works within "+
-			"allowed directories."),
+		mcp.WithDescription(`description: Create a new directory at the specified path. Automatically creates any necessary parent directories that don't exist (similar to mkdir -p). Only works within allowed directories.
+demo_commands: [{"path": "./new_directory"}, {"path": "./parent/child/grandchild"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to create"),
@@ -159,8 +148,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register delete_directory tool
 	deleteDirectoryTool := mcp.NewTool("delete_directory",
-		mcp.WithDescription("Delete a directory at the specified path. Can optionally delete "+
-			"non-empty directories recursively. Only works within allowed directories."),
+		mcp.WithDescription(`description: Delete a directory at the specified path. By default, only empty directories can be deleted. Set recursive to true to delete all contents within the directory as well.
+demo_commands: [{"path": "./empty_dir"}, {"path": "./project_backup", "recursive": true}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to delete"),
@@ -175,7 +164,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register delete_file tool
 	deleteFileTool := mcp.NewTool("delete_file",
-		mcp.WithDescription("Delete a file at the specified path. Only works within allowed directories."),
+		mcp.WithDescription(`description: Delete a file at the specified path. This permanently removes the file from the filesystem. Only works within allowed directories.
+demo_commands: [{"path": "./temp.txt"}, {"path": "./logs/old_log.txt"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to delete"),
@@ -187,8 +177,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register move_file tool
 	moveFileTool := mcp.NewTool("move_file",
-		mcp.WithDescription("Move a file from one location to another. This can also be used "+
-			"to rename files. Only works within allowed directories."),
+		mcp.WithDescription(`description: Move or rename a file from source_path to destination_path. This is equivalent to both moving a file to a different directory and renaming it in the same directory. Both paths must be within allowed directories.
+demo_commands: [{"source_path": "./old_name.txt", "destination_path": "./new_name.txt"}, {"source_path": "./file.txt", "destination_path": "./subfolder/file.txt"}]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to move"),
@@ -204,7 +194,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register copy_file tool
 	copyFileTool := mcp.NewTool("copy_file",
-		mcp.WithDescription("Copy a file from one location to another. Only works within allowed directories."),
+		mcp.WithDescription(`description: Copy a file from source_path to destination_path while keeping the original file intact. This creates a duplicate of the file at the new location. Both paths must be within allowed directories.
+demo_commands: [{"source_path": "./template.html", "destination_path": "./pages/new_page.html"}, {"source_path": "./config.json", "destination_path": "./config_backup.json"}]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to copy"),
@@ -220,9 +211,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register search_files tool
 	searchFilesTool := mcp.NewTool("search_files",
-		mcp.WithDescription("Search for files containing the specified query string. "+
-			"Returns matching files with line numbers and context. "+
-			"Only works within allowed directories."),
+		mcp.WithDescription(`description: Search for text content within files in a directory. Returns matching files with line numbers and surrounding context for each match. Set recursive to true to search in all subdirectories recursively.
+demo_commands: [{"query": "function main", "path": "./src", "recursive": true}, {"query": "TODO", "path": "./", "recursive": false}]`),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Text to search for"),
@@ -241,8 +231,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 
 	// Register list_allowed_directories tool
 	listAllowedDirectoriesTool := mcp.NewTool("list_allowed_directories",
-		mcp.WithDescription("List all directories that are allowed to be accessed by the filesystem tools. "+
-			"This provides transparency about which directories can be manipulated using the filesystem tools."),
+		mcp.WithDescription(`description: List all directories that are allowed to be accessed by the filesystem tools. This helps you understand which paths you can work with using the other tools. The response is a JSON array of directory paths.
+demo_commands: [{"hi": ""}]`),
 		mcp.WithString("hi",
 			mcp.Description("no effect"),
 		),

--- a/internal/tools/registration.go
+++ b/internal/tools/registration.go
@@ -52,7 +52,11 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 	// Register read_file tool
 	readFileTool := mcp.NewTool("read_file",
 		mcp.WithDescription(`description: Read the complete contents of a file from the file system. This tool safely reads files only within allowed directories and handles various encodings. Returns the full text content of the specified file.
-demo_commands: [{"path": "/allowed/directory/file.txt"}, {"path": "/allowed/directory/documents/document.md"}]`),
+demo_commands: [
+  path: /allowed/directory/file.txt
+,
+  path: /allowed/directory/documents/document.md
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to read"),
@@ -65,7 +69,14 @@ demo_commands: [{"path": "/allowed/directory/file.txt"}, {"path": "/allowed/dire
 	// Register read_multiple_files tool
 	readMultipleFilesTool := mcp.NewTool("read_multiple_files",
 		mcp.WithDescription(`description: Read multiple files in a single operation. This is more efficient than making separate read requests when analyzing related files. Provide a JSON array of file paths, and receive a JSON object mapping each path to its content.
-demo_commands: [{"paths": "[\"/allowed/directory/config.json\", \"/allowed/directory/settings.yaml\", \"/allowed/directory/data/sample.txt\"]"}]`),
+demo_commands: [
+  paths: |
+    [
+      "/allowed/directory/config.json", 
+      "/allowed/directory/settings.yaml", 
+      "/allowed/directory/data/sample.txt"
+    ]
+]`),
 		mcp.WithString("paths",
 			mcp.Required(),
 			mcp.Description("JSON array of paths to the files to read"),
@@ -78,7 +89,14 @@ demo_commands: [{"paths": "[\"/allowed/directory/config.json\", \"/allowed/direc
 	// Register write_file tool
 	writeFileTool := mcp.NewTool("write_file",
 		mcp.WithDescription(`description: Write content to a file, creating it if it doesn't exist or overwriting/appending if it does. Use the append flag to add content to the end of an existing file rather than replacing its contents.
-demo_commands: [{"path": "/allowed/directory/new_file.txt", "content": "Hello, world!"}, {"path": "/allowed/directory/logs/app.log", "content": "New log entry", "append": true}]`),
+demo_commands: [
+  path: /allowed/directory/new_file.txt
+  content: Hello, world!
+,
+  path: /allowed/directory/logs/app.log
+  content: New log entry
+  append: true
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to write"),
@@ -98,7 +116,17 @@ demo_commands: [{"path": "/allowed/directory/new_file.txt", "content": "Hello, w
 	// Register edit_file tool
 	editFileTool := mcp.NewTool("edit_file",
 		mcp.WithDescription(`description: Edit a specific portion of a file by replacing lines between start_line and end_line with new content. This is useful for making precise changes without rewriting the entire file. Line numbers are 1-indexed.
-demo_commands: [{"path": "/allowed/directory/config.json", "content": "  \"debug\": true,", "start_line": 5, "end_line": 5}, {"path": "/allowed/directory/src/main.go", "content": "// TODO: Implement error handling", "start_line": 42, "end_line": 45}]`),
+demo_commands: [
+  path: /allowed/directory/config.json
+  content: "  \"debug\": true,"
+  start_line: 5
+  end_line: 5
+,
+  path: /allowed/directory/src/main.go
+  content: "// TODO: Implement error handling"
+  start_line: 42
+  end_line: 45
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to edit"),
@@ -123,7 +151,13 @@ demo_commands: [{"path": "/allowed/directory/config.json", "content": "  \"debug
 	// Register list_directory tool
 	listDirectoryTool := mcp.NewTool("list_directory",
 		mcp.WithDescription(`description: List all files and subdirectories in a specified directory, including metadata like file size, modification time, and file type. Returns a JSON array of entry objects.
-demo_commands: [{"path": "/allowed/directory"}, {"path": "/allowed/directory/src"}, {"path": "/allowed/directory/data"}]`),
+demo_commands: [
+  path: /allowed/directory
+,
+  path: /allowed/directory/src
+,
+  path: /allowed/directory/data
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to list"),
@@ -136,7 +170,11 @@ demo_commands: [{"path": "/allowed/directory"}, {"path": "/allowed/directory/src
 	// Register create_directory tool
 	createDirectoryTool := mcp.NewTool("create_directory",
 		mcp.WithDescription(`description: Create a new directory at the specified path. Automatically creates any necessary parent directories that don't exist (similar to mkdir -p). Only works within allowed directories.
-demo_commands: [{"path": "/allowed/directory/new_directory"}, {"path": "/allowed/directory/parent/child/grandchild"}]`),
+demo_commands: [
+  path: /allowed/directory/new_directory
+,
+  path: /allowed/directory/parent/child/grandchild
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to create"),
@@ -149,7 +187,12 @@ demo_commands: [{"path": "/allowed/directory/new_directory"}, {"path": "/allowed
 	// Register delete_directory tool
 	deleteDirectoryTool := mcp.NewTool("delete_directory",
 		mcp.WithDescription(`description: Delete a directory at the specified path. By default, only empty directories can be deleted. Set recursive to true to delete all contents within the directory as well.
-demo_commands: [{"path": "/allowed/directory/empty_dir"}, {"path": "/allowed/directory/project_backup", "recursive": true}]`),
+demo_commands: [
+  path: /allowed/directory/empty_dir
+,
+  path: /allowed/directory/project_backup
+  recursive: true
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to delete"),
@@ -165,7 +208,11 @@ demo_commands: [{"path": "/allowed/directory/empty_dir"}, {"path": "/allowed/dir
 	// Register delete_file tool
 	deleteFileTool := mcp.NewTool("delete_file",
 		mcp.WithDescription(`description: Delete a file at the specified path. This permanently removes the file from the filesystem. Only works within allowed directories.
-demo_commands: [{"path": "/allowed/directory/temp.txt"}, {"path": "/allowed/directory/logs/old_log.txt"}]`),
+demo_commands: [
+  path: /allowed/directory/temp.txt
+,
+  path: /allowed/directory/logs/old_log.txt
+]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to delete"),
@@ -178,7 +225,13 @@ demo_commands: [{"path": "/allowed/directory/temp.txt"}, {"path": "/allowed/dire
 	// Register move_file tool
 	moveFileTool := mcp.NewTool("move_file",
 		mcp.WithDescription(`description: Move or rename a file from source_path to destination_path. This is equivalent to both moving a file to a different directory and renaming it in the same directory. Both paths must be within allowed directories.
-demo_commands: [{"source_path": "/allowed/directory/old_name.txt", "destination_path": "/allowed/directory/new_name.txt"}, {"source_path": "/allowed/directory/file.txt", "destination_path": "/allowed/directory/subfolder/file.txt"}]`),
+demo_commands: [
+  source_path: /allowed/directory/old_name.txt
+  destination_path: /allowed/directory/new_name.txt
+,
+  source_path: /allowed/directory/file.txt
+  destination_path: /allowed/directory/subfolder/file.txt
+]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to move"),
@@ -195,7 +248,13 @@ demo_commands: [{"source_path": "/allowed/directory/old_name.txt", "destination_
 	// Register copy_file tool
 	copyFileTool := mcp.NewTool("copy_file",
 		mcp.WithDescription(`description: Copy a file from source_path to destination_path while keeping the original file intact. This creates a duplicate of the file at the new location. Both paths must be within allowed directories.
-demo_commands: [{"source_path": "/allowed/directory/template.html", "destination_path": "/allowed/directory/pages/new_page.html"}, {"source_path": "/allowed/directory/config.json", "destination_path": "/allowed/directory/config_backup.json"}]`),
+demo_commands: [
+  source_path: /allowed/directory/template.html
+  destination_path: /allowed/directory/pages/new_page.html
+,
+  source_path: /allowed/directory/config.json
+  destination_path: /allowed/directory/config_backup.json
+]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to copy"),
@@ -212,7 +271,15 @@ demo_commands: [{"source_path": "/allowed/directory/template.html", "destination
 	// Register search_files tool
 	searchFilesTool := mcp.NewTool("search_files",
 		mcp.WithDescription(`description: Search for text content within files in a directory. Returns matching files with line numbers and surrounding context for each match. Set recursive to true to search in all subdirectories recursively.
-demo_commands: [{"query": "function main", "path": "/allowed/directory/src", "recursive": true}, {"query": "TODO", "path": "/allowed/directory", "recursive": false}]`),
+demo_commands: [
+  query: function main
+  path: /allowed/directory/src
+  recursive: true
+,
+  query: TODO
+  path: /allowed/directory
+  recursive: false
+]`),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Text to search for"),
@@ -232,7 +299,9 @@ demo_commands: [{"query": "function main", "path": "/allowed/directory/src", "re
 	// Register list_allowed_directories tool
 	listAllowedDirectoriesTool := mcp.NewTool("list_allowed_directories",
 		mcp.WithDescription(`description: List all directories that are allowed to be accessed by the filesystem tools. This helps you understand which paths you can work with using the other tools. The response is a JSON array of directory paths.
-demo_commands: [{"hi": ""}]`),
+demo_commands: [
+  hi: ""
+]`),
 		mcp.WithString("hi",
 			mcp.Description("no effect"),
 		),

--- a/internal/tools/registration.go
+++ b/internal/tools/registration.go
@@ -52,10 +52,9 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 	// Register read_file tool
 	readFileTool := mcp.NewTool("read_file",
 		mcp.WithDescription(`description: Read the complete contents of a file from the file system. This tool safely reads files only within allowed directories and handles various encodings. Returns the full text content of the specified file.
-demo_commands: [
-- path: /allowed/directory/file.txt
-- path: /allowed/directory/documents/document.md
-]`),
+demo_commands:
+- /allowed/directory/file.txt
+- /allowed/directory/documents/document.md`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to read"),
@@ -68,14 +67,13 @@ demo_commands: [
 	// Register read_multiple_files tool
 	readMultipleFilesTool := mcp.NewTool("read_multiple_files",
 		mcp.WithDescription(`description: Read multiple files in a single operation. This is more efficient than making separate read requests when analyzing related files. Provide a JSON array of file paths, and receive a JSON object mapping each path to its content.
-demo_commands: [
+demo_commands:
 - paths: |
     [
       "/allowed/directory/config.json", 
       "/allowed/directory/settings.yaml", 
       "/allowed/directory/data/sample.txt"
-    ]
-]`),
+    ]`),
 		mcp.WithString("paths",
 			mcp.Required(),
 			mcp.Description("JSON array of paths to the files to read"),
@@ -88,13 +86,12 @@ demo_commands: [
 	// Register write_file tool
 	writeFileTool := mcp.NewTool("write_file",
 		mcp.WithDescription(`description: Write content to a file, creating it if it doesn't exist or overwriting/appending if it does. Use the append flag to add content to the end of an existing file rather than replacing its contents.
-demo_commands: [
+demo_commands:
 - path: /allowed/directory/new_file.txt
   content: Hello, world!
 - path: /allowed/directory/logs/app.log
   content: New log entry
-  append: true
-]`),
+  append: true`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to write"),
@@ -114,7 +111,7 @@ demo_commands: [
 	// Register edit_file tool
 	editFileTool := mcp.NewTool("edit_file",
 		mcp.WithDescription(`description: Edit a specific portion of a file by replacing lines between start_line and end_line with new content. This is useful for making precise changes without rewriting the entire file. Line numbers are 1-indexed.
-demo_commands: [
+demo_commands:
 - path: /allowed/directory/config.json
   content: "  \"debug\": true,"
   start_line: 5
@@ -122,8 +119,7 @@ demo_commands: [
 - path: /allowed/directory/src/main.go
   content: "// TODO: Implement error handling"
   start_line: 42
-  end_line: 45
-]`),
+  end_line: 45`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to edit"),
@@ -148,11 +144,10 @@ demo_commands: [
 	// Register list_directory tool
 	listDirectoryTool := mcp.NewTool("list_directory",
 		mcp.WithDescription(`description: List all files and subdirectories in a specified directory, including metadata like file size, modification time, and file type. Returns a JSON array of entry objects.
-demo_commands: [
-- path: /allowed/directory
-- path: /allowed/directory/src
-- path: /allowed/directory/data
-]`),
+demo_commands:
+- /allowed/directory
+- /allowed/directory/src
+- /allowed/directory/data`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to list"),
@@ -165,10 +160,9 @@ demo_commands: [
 	// Register create_directory tool
 	createDirectoryTool := mcp.NewTool("create_directory",
 		mcp.WithDescription(`description: Create a new directory at the specified path. Automatically creates any necessary parent directories that don't exist (similar to mkdir -p). Only works within allowed directories.
-demo_commands: [
-- path: /allowed/directory/new_directory
-- path: /allowed/directory/parent/child/grandchild
-]`),
+demo_commands:
+- /allowed/directory/new_directory
+- /allowed/directory/parent/child/grandchild`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to create"),
@@ -181,11 +175,10 @@ demo_commands: [
 	// Register delete_directory tool
 	deleteDirectoryTool := mcp.NewTool("delete_directory",
 		mcp.WithDescription(`description: Delete a directory at the specified path. By default, only empty directories can be deleted. Set recursive to true to delete all contents within the directory as well.
-demo_commands: [
-- path: /allowed/directory/empty_dir
+demo_commands:
+- /allowed/directory/empty_dir
 - path: /allowed/directory/project_backup
-  recursive: true
-]`),
+  recursive: true`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to delete"),
@@ -201,10 +194,9 @@ demo_commands: [
 	// Register delete_file tool
 	deleteFileTool := mcp.NewTool("delete_file",
 		mcp.WithDescription(`description: Delete a file at the specified path. This permanently removes the file from the filesystem. Only works within allowed directories.
-demo_commands: [
-- path: /allowed/directory/temp.txt
-- path: /allowed/directory/logs/old_log.txt
-]`),
+demo_commands:
+- /allowed/directory/temp.txt
+- /allowed/directory/logs/old_log.txt`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to delete"),
@@ -217,12 +209,11 @@ demo_commands: [
 	// Register move_file tool
 	moveFileTool := mcp.NewTool("move_file",
 		mcp.WithDescription(`description: Move or rename a file from source_path to destination_path. This is equivalent to both moving a file to a different directory and renaming it in the same directory. Both paths must be within allowed directories.
-demo_commands: [
+demo_commands:
 - source_path: /allowed/directory/old_name.txt
   destination_path: /allowed/directory/new_name.txt
 - source_path: /allowed/directory/file.txt
-  destination_path: /allowed/directory/subfolder/file.txt
-]`),
+  destination_path: /allowed/directory/subfolder/file.txt`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to move"),
@@ -239,12 +230,11 @@ demo_commands: [
 	// Register copy_file tool
 	copyFileTool := mcp.NewTool("copy_file",
 		mcp.WithDescription(`description: Copy a file from source_path to destination_path while keeping the original file intact. This creates a duplicate of the file at the new location. Both paths must be within allowed directories.
-demo_commands: [
+demo_commands:
 - source_path: /allowed/directory/template.html
   destination_path: /allowed/directory/pages/new_page.html
 - source_path: /allowed/directory/config.json
-  destination_path: /allowed/directory/config_backup.json
-]`),
+  destination_path: /allowed/directory/config_backup.json`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to copy"),
@@ -261,14 +251,13 @@ demo_commands: [
 	// Register search_files tool
 	searchFilesTool := mcp.NewTool("search_files",
 		mcp.WithDescription(`description: Search for text content within files in a directory. Returns matching files with line numbers and surrounding context for each match. Set recursive to true to search in all subdirectories recursively.
-demo_commands: [
+demo_commands:
 - query: function main
   path: /allowed/directory/src
   recursive: true
 - query: TODO
   path: /allowed/directory
-  recursive: false
-]`),
+  recursive: false`),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Text to search for"),
@@ -288,9 +277,8 @@ demo_commands: [
 	// Register list_allowed_directories tool
 	listAllowedDirectoriesTool := mcp.NewTool("list_allowed_directories",
 		mcp.WithDescription(`description: List all directories that are allowed to be accessed by the filesystem tools. This helps you understand which paths you can work with using the other tools. The response is a JSON array of directory paths.
-demo_commands: [
-- hi: ""
-]`),
+demo_commands:
+- hi: ""`),
 		mcp.WithString("hi",
 			mcp.Description("no effect"),
 		),

--- a/internal/tools/registration.go
+++ b/internal/tools/registration.go
@@ -52,7 +52,7 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 	// Register read_file tool
 	readFileTool := mcp.NewTool("read_file",
 		mcp.WithDescription(`description: Read the complete contents of a file from the file system. This tool safely reads files only within allowed directories and handles various encodings. Returns the full text content of the specified file.
-demo_commands: [{"path": "/path/to/file.txt"}, {"path": "./relative/path/document.md"}]`),
+demo_commands: [{"path": "/allowed/directory/file.txt"}, {"path": "/allowed/directory/documents/document.md"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to read"),
@@ -65,7 +65,7 @@ demo_commands: [{"path": "/path/to/file.txt"}, {"path": "./relative/path/documen
 	// Register read_multiple_files tool
 	readMultipleFilesTool := mcp.NewTool("read_multiple_files",
 		mcp.WithDescription(`description: Read multiple files in a single operation. This is more efficient than making separate read requests when analyzing related files. Provide a JSON array of file paths, and receive a JSON object mapping each path to its content.
-demo_commands: [{"paths": "[\"./config.json\", \"./settings.yaml\", \"./data/sample.txt\"]"}]`),
+demo_commands: [{"paths": "[\"/allowed/directory/config.json\", \"/allowed/directory/settings.yaml\", \"/allowed/directory/data/sample.txt\"]"}]`),
 		mcp.WithString("paths",
 			mcp.Required(),
 			mcp.Description("JSON array of paths to the files to read"),
@@ -78,7 +78,7 @@ demo_commands: [{"paths": "[\"./config.json\", \"./settings.yaml\", \"./data/sam
 	// Register write_file tool
 	writeFileTool := mcp.NewTool("write_file",
 		mcp.WithDescription(`description: Write content to a file, creating it if it doesn't exist or overwriting/appending if it does. Use the append flag to add content to the end of an existing file rather than replacing its contents.
-demo_commands: [{"path": "./new_file.txt", "content": "Hello, world!"}, {"path": "./logs.txt", "content": "New log entry", "append": true}]`),
+demo_commands: [{"path": "/allowed/directory/new_file.txt", "content": "Hello, world!"}, {"path": "/allowed/directory/logs/app.log", "content": "New log entry", "append": true}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to write"),
@@ -98,7 +98,7 @@ demo_commands: [{"path": "./new_file.txt", "content": "Hello, world!"}, {"path":
 	// Register edit_file tool
 	editFileTool := mcp.NewTool("edit_file",
 		mcp.WithDescription(`description: Edit a specific portion of a file by replacing lines between start_line and end_line with new content. This is useful for making precise changes without rewriting the entire file. Line numbers are 1-indexed.
-demo_commands: [{"path": "./config.json", "content": "  \"debug\": true,", "start_line": 5, "end_line": 5}, {"path": "./src/main.go", "content": "// TODO: Implement error handling", "start_line": 42, "end_line": 45}]`),
+demo_commands: [{"path": "/allowed/directory/config.json", "content": "  \"debug\": true,", "start_line": 5, "end_line": 5}, {"path": "/allowed/directory/src/main.go", "content": "// TODO: Implement error handling", "start_line": 42, "end_line": 45}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to edit"),
@@ -123,7 +123,7 @@ demo_commands: [{"path": "./config.json", "content": "  \"debug\": true,", "star
 	// Register list_directory tool
 	listDirectoryTool := mcp.NewTool("list_directory",
 		mcp.WithDescription(`description: List all files and subdirectories in a specified directory, including metadata like file size, modification time, and file type. Returns a JSON array of entry objects.
-demo_commands: [{"path": "."}, {"path": "./src"}, {"path": "/allowed/directory/path"}]`),
+demo_commands: [{"path": "/allowed/directory"}, {"path": "/allowed/directory/src"}, {"path": "/allowed/directory/data"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to list"),
@@ -136,7 +136,7 @@ demo_commands: [{"path": "."}, {"path": "./src"}, {"path": "/allowed/directory/p
 	// Register create_directory tool
 	createDirectoryTool := mcp.NewTool("create_directory",
 		mcp.WithDescription(`description: Create a new directory at the specified path. Automatically creates any necessary parent directories that don't exist (similar to mkdir -p). Only works within allowed directories.
-demo_commands: [{"path": "./new_directory"}, {"path": "./parent/child/grandchild"}]`),
+demo_commands: [{"path": "/allowed/directory/new_directory"}, {"path": "/allowed/directory/parent/child/grandchild"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to create"),
@@ -149,7 +149,7 @@ demo_commands: [{"path": "./new_directory"}, {"path": "./parent/child/grandchild
 	// Register delete_directory tool
 	deleteDirectoryTool := mcp.NewTool("delete_directory",
 		mcp.WithDescription(`description: Delete a directory at the specified path. By default, only empty directories can be deleted. Set recursive to true to delete all contents within the directory as well.
-demo_commands: [{"path": "./empty_dir"}, {"path": "./project_backup", "recursive": true}]`),
+demo_commands: [{"path": "/allowed/directory/empty_dir"}, {"path": "/allowed/directory/project_backup", "recursive": true}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to delete"),
@@ -165,7 +165,7 @@ demo_commands: [{"path": "./empty_dir"}, {"path": "./project_backup", "recursive
 	// Register delete_file tool
 	deleteFileTool := mcp.NewTool("delete_file",
 		mcp.WithDescription(`description: Delete a file at the specified path. This permanently removes the file from the filesystem. Only works within allowed directories.
-demo_commands: [{"path": "./temp.txt"}, {"path": "./logs/old_log.txt"}]`),
+demo_commands: [{"path": "/allowed/directory/temp.txt"}, {"path": "/allowed/directory/logs/old_log.txt"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to delete"),
@@ -178,7 +178,7 @@ demo_commands: [{"path": "./temp.txt"}, {"path": "./logs/old_log.txt"}]`),
 	// Register move_file tool
 	moveFileTool := mcp.NewTool("move_file",
 		mcp.WithDescription(`description: Move or rename a file from source_path to destination_path. This is equivalent to both moving a file to a different directory and renaming it in the same directory. Both paths must be within allowed directories.
-demo_commands: [{"source_path": "./old_name.txt", "destination_path": "./new_name.txt"}, {"source_path": "./file.txt", "destination_path": "./subfolder/file.txt"}]`),
+demo_commands: [{"source_path": "/allowed/directory/old_name.txt", "destination_path": "/allowed/directory/new_name.txt"}, {"source_path": "/allowed/directory/file.txt", "destination_path": "/allowed/directory/subfolder/file.txt"}]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to move"),
@@ -195,7 +195,7 @@ demo_commands: [{"source_path": "./old_name.txt", "destination_path": "./new_nam
 	// Register copy_file tool
 	copyFileTool := mcp.NewTool("copy_file",
 		mcp.WithDescription(`description: Copy a file from source_path to destination_path while keeping the original file intact. This creates a duplicate of the file at the new location. Both paths must be within allowed directories.
-demo_commands: [{"source_path": "./template.html", "destination_path": "./pages/new_page.html"}, {"source_path": "./config.json", "destination_path": "./config_backup.json"}]`),
+demo_commands: [{"source_path": "/allowed/directory/template.html", "destination_path": "/allowed/directory/pages/new_page.html"}, {"source_path": "/allowed/directory/config.json", "destination_path": "/allowed/directory/config_backup.json"}]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to copy"),
@@ -212,7 +212,7 @@ demo_commands: [{"source_path": "./template.html", "destination_path": "./pages/
 	// Register search_files tool
 	searchFilesTool := mcp.NewTool("search_files",
 		mcp.WithDescription(`description: Search for text content within files in a directory. Returns matching files with line numbers and surrounding context for each match. Set recursive to true to search in all subdirectories recursively.
-demo_commands: [{"query": "function main", "path": "./src", "recursive": true}, {"query": "TODO", "path": "./", "recursive": false}]`),
+demo_commands: [{"query": "function main", "path": "/allowed/directory/src", "recursive": true}, {"query": "TODO", "path": "/allowed/directory", "recursive": false}]`),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Text to search for"),

--- a/internal/tools/registration.go
+++ b/internal/tools/registration.go
@@ -52,9 +52,7 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 	// Register read_file tool
 	readFileTool := mcp.NewTool("read_file",
 		mcp.WithDescription(`description: Read the complete contents of a file from the file system. This tool safely reads files only within allowed directories and handles various encodings. Returns the full text content of the specified file.
-demo_commands:
-- /allowed/directory/file.txt
-- /allowed/directory/documents/document.md`),
+demo_commands: [{"path": "/allowed/directory/file.txt"}, {"path": "/allowed/directory/documents/document.md"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to read"),
@@ -67,13 +65,7 @@ demo_commands:
 	// Register read_multiple_files tool
 	readMultipleFilesTool := mcp.NewTool("read_multiple_files",
 		mcp.WithDescription(`description: Read multiple files in a single operation. This is more efficient than making separate read requests when analyzing related files. Provide a JSON array of file paths, and receive a JSON object mapping each path to its content.
-demo_commands:
-- paths: |
-    [
-      "/allowed/directory/config.json", 
-      "/allowed/directory/settings.yaml", 
-      "/allowed/directory/data/sample.txt"
-    ]`),
+demo_commands: [{"paths": "[\"/allowed/directory/config.json\", \"/allowed/directory/settings.yaml\", \"/allowed/directory/data/sample.txt\"]"}]`),
 		mcp.WithString("paths",
 			mcp.Required(),
 			mcp.Description("JSON array of paths to the files to read"),
@@ -86,12 +78,7 @@ demo_commands:
 	// Register write_file tool
 	writeFileTool := mcp.NewTool("write_file",
 		mcp.WithDescription(`description: Write content to a file, creating it if it doesn't exist or overwriting/appending if it does. Use the append flag to add content to the end of an existing file rather than replacing its contents.
-demo_commands:
-- path: /allowed/directory/new_file.txt
-  content: Hello, world!
-- path: /allowed/directory/logs/app.log
-  content: New log entry
-  append: true`),
+demo_commands: [{"path": "/allowed/directory/new_file.txt", "content": "Hello, world!"}, {"path": "/allowed/directory/logs/app.log", "content": "New log entry", "append": true}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to write"),
@@ -111,15 +98,7 @@ demo_commands:
 	// Register edit_file tool
 	editFileTool := mcp.NewTool("edit_file",
 		mcp.WithDescription(`description: Edit a specific portion of a file by replacing lines between start_line and end_line with new content. This is useful for making precise changes without rewriting the entire file. Line numbers are 1-indexed.
-demo_commands:
-- path: /allowed/directory/config.json
-  content: "  \"debug\": true,"
-  start_line: 5
-  end_line: 5
-- path: /allowed/directory/src/main.go
-  content: "// TODO: Implement error handling"
-  start_line: 42
-  end_line: 45`),
+demo_commands: [{"path": "/allowed/directory/config.json", "content": "  \"debug\": true,", "start_line": 5, "end_line": 5}, {"path": "/allowed/directory/src/main.go", "content": "// TODO: Implement error handling", "start_line": 42, "end_line": 45}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to edit"),
@@ -144,10 +123,7 @@ demo_commands:
 	// Register list_directory tool
 	listDirectoryTool := mcp.NewTool("list_directory",
 		mcp.WithDescription(`description: List all files and subdirectories in a specified directory, including metadata like file size, modification time, and file type. Returns a JSON array of entry objects.
-demo_commands:
-- /allowed/directory
-- /allowed/directory/src
-- /allowed/directory/data`),
+demo_commands: [{"path": "/allowed/directory"}, {"path": "/allowed/directory/src"}, {"path": "/allowed/directory/data"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to list"),
@@ -160,9 +136,7 @@ demo_commands:
 	// Register create_directory tool
 	createDirectoryTool := mcp.NewTool("create_directory",
 		mcp.WithDescription(`description: Create a new directory at the specified path. Automatically creates any necessary parent directories that don't exist (similar to mkdir -p). Only works within allowed directories.
-demo_commands:
-- /allowed/directory/new_directory
-- /allowed/directory/parent/child/grandchild`),
+demo_commands: [{"path": "/allowed/directory/new_directory"}, {"path": "/allowed/directory/parent/child/grandchild"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to create"),
@@ -175,10 +149,7 @@ demo_commands:
 	// Register delete_directory tool
 	deleteDirectoryTool := mcp.NewTool("delete_directory",
 		mcp.WithDescription(`description: Delete a directory at the specified path. By default, only empty directories can be deleted. Set recursive to true to delete all contents within the directory as well.
-demo_commands:
-- /allowed/directory/empty_dir
-- path: /allowed/directory/project_backup
-  recursive: true`),
+demo_commands: [{"path": "/allowed/directory/empty_dir"}, {"path": "/allowed/directory/project_backup", "recursive": true}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the directory to delete"),
@@ -194,9 +165,7 @@ demo_commands:
 	// Register delete_file tool
 	deleteFileTool := mcp.NewTool("delete_file",
 		mcp.WithDescription(`description: Delete a file at the specified path. This permanently removes the file from the filesystem. Only works within allowed directories.
-demo_commands:
-- /allowed/directory/temp.txt
-- /allowed/directory/logs/old_log.txt`),
+demo_commands: [{"path": "/allowed/directory/temp.txt"}, {"path": "/allowed/directory/logs/old_log.txt"}]`),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to the file to delete"),
@@ -209,11 +178,7 @@ demo_commands:
 	// Register move_file tool
 	moveFileTool := mcp.NewTool("move_file",
 		mcp.WithDescription(`description: Move or rename a file from source_path to destination_path. This is equivalent to both moving a file to a different directory and renaming it in the same directory. Both paths must be within allowed directories.
-demo_commands:
-- source_path: /allowed/directory/old_name.txt
-  destination_path: /allowed/directory/new_name.txt
-- source_path: /allowed/directory/file.txt
-  destination_path: /allowed/directory/subfolder/file.txt`),
+demo_commands: [{"source_path": "/allowed/directory/old_name.txt", "destination_path": "/allowed/directory/new_name.txt"}, {"source_path": "/allowed/directory/file.txt", "destination_path": "/allowed/directory/subfolder/file.txt"}]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to move"),
@@ -230,11 +195,7 @@ demo_commands:
 	// Register copy_file tool
 	copyFileTool := mcp.NewTool("copy_file",
 		mcp.WithDescription(`description: Copy a file from source_path to destination_path while keeping the original file intact. This creates a duplicate of the file at the new location. Both paths must be within allowed directories.
-demo_commands:
-- source_path: /allowed/directory/template.html
-  destination_path: /allowed/directory/pages/new_page.html
-- source_path: /allowed/directory/config.json
-  destination_path: /allowed/directory/config_backup.json`),
+demo_commands: [{"source_path": "/allowed/directory/template.html", "destination_path": "/allowed/directory/pages/new_page.html"}, {"source_path": "/allowed/directory/config.json", "destination_path": "/allowed/directory/config_backup.json"}]`),
 		mcp.WithString("source_path",
 			mcp.Required(),
 			mcp.Description("Path to the file to copy"),
@@ -251,13 +212,7 @@ demo_commands:
 	// Register search_files tool
 	searchFilesTool := mcp.NewTool("search_files",
 		mcp.WithDescription(`description: Search for text content within files in a directory. Returns matching files with line numbers and surrounding context for each match. Set recursive to true to search in all subdirectories recursively.
-demo_commands:
-- query: function main
-  path: /allowed/directory/src
-  recursive: true
-- query: TODO
-  path: /allowed/directory
-  recursive: false`),
+demo_commands: [{"query": "function main", "path": "/allowed/directory/src", "recursive": true}, {"query": "TODO", "path": "/allowed/directory", "recursive": false}]`),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Text to search for"),
@@ -277,8 +232,7 @@ demo_commands:
 	// Register list_allowed_directories tool
 	listAllowedDirectoriesTool := mcp.NewTool("list_allowed_directories",
 		mcp.WithDescription(`description: List all directories that are allowed to be accessed by the filesystem tools. This helps you understand which paths you can work with using the other tools. The response is a JSON array of directory paths.
-demo_commands:
-- hi: ""`),
+demo_commands: [{"hi": ""}]`),
 		mcp.WithString("hi",
 			mcp.Description("no effect"),
 		),

--- a/internal/tools/registration.go
+++ b/internal/tools/registration.go
@@ -53,9 +53,8 @@ func RegisterTools(s *server.MCPServer, allowedDirectories []string) {
 	readFileTool := mcp.NewTool("read_file",
 		mcp.WithDescription(`description: Read the complete contents of a file from the file system. This tool safely reads files only within allowed directories and handles various encodings. Returns the full text content of the specified file.
 demo_commands: [
-  path: /allowed/directory/file.txt
-,
-  path: /allowed/directory/documents/document.md
+- path: /allowed/directory/file.txt
+- path: /allowed/directory/documents/document.md
 ]`),
 		mcp.WithString("path",
 			mcp.Required(),
@@ -70,7 +69,7 @@ demo_commands: [
 	readMultipleFilesTool := mcp.NewTool("read_multiple_files",
 		mcp.WithDescription(`description: Read multiple files in a single operation. This is more efficient than making separate read requests when analyzing related files. Provide a JSON array of file paths, and receive a JSON object mapping each path to its content.
 demo_commands: [
-  paths: |
+- paths: |
     [
       "/allowed/directory/config.json", 
       "/allowed/directory/settings.yaml", 
@@ -90,10 +89,9 @@ demo_commands: [
 	writeFileTool := mcp.NewTool("write_file",
 		mcp.WithDescription(`description: Write content to a file, creating it if it doesn't exist or overwriting/appending if it does. Use the append flag to add content to the end of an existing file rather than replacing its contents.
 demo_commands: [
-  path: /allowed/directory/new_file.txt
+- path: /allowed/directory/new_file.txt
   content: Hello, world!
-,
-  path: /allowed/directory/logs/app.log
+- path: /allowed/directory/logs/app.log
   content: New log entry
   append: true
 ]`),
@@ -117,12 +115,11 @@ demo_commands: [
 	editFileTool := mcp.NewTool("edit_file",
 		mcp.WithDescription(`description: Edit a specific portion of a file by replacing lines between start_line and end_line with new content. This is useful for making precise changes without rewriting the entire file. Line numbers are 1-indexed.
 demo_commands: [
-  path: /allowed/directory/config.json
+- path: /allowed/directory/config.json
   content: "  \"debug\": true,"
   start_line: 5
   end_line: 5
-,
-  path: /allowed/directory/src/main.go
+- path: /allowed/directory/src/main.go
   content: "// TODO: Implement error handling"
   start_line: 42
   end_line: 45
@@ -152,11 +149,9 @@ demo_commands: [
 	listDirectoryTool := mcp.NewTool("list_directory",
 		mcp.WithDescription(`description: List all files and subdirectories in a specified directory, including metadata like file size, modification time, and file type. Returns a JSON array of entry objects.
 demo_commands: [
-  path: /allowed/directory
-,
-  path: /allowed/directory/src
-,
-  path: /allowed/directory/data
+- path: /allowed/directory
+- path: /allowed/directory/src
+- path: /allowed/directory/data
 ]`),
 		mcp.WithString("path",
 			mcp.Required(),
@@ -171,9 +166,8 @@ demo_commands: [
 	createDirectoryTool := mcp.NewTool("create_directory",
 		mcp.WithDescription(`description: Create a new directory at the specified path. Automatically creates any necessary parent directories that don't exist (similar to mkdir -p). Only works within allowed directories.
 demo_commands: [
-  path: /allowed/directory/new_directory
-,
-  path: /allowed/directory/parent/child/grandchild
+- path: /allowed/directory/new_directory
+- path: /allowed/directory/parent/child/grandchild
 ]`),
 		mcp.WithString("path",
 			mcp.Required(),
@@ -188,9 +182,8 @@ demo_commands: [
 	deleteDirectoryTool := mcp.NewTool("delete_directory",
 		mcp.WithDescription(`description: Delete a directory at the specified path. By default, only empty directories can be deleted. Set recursive to true to delete all contents within the directory as well.
 demo_commands: [
-  path: /allowed/directory/empty_dir
-,
-  path: /allowed/directory/project_backup
+- path: /allowed/directory/empty_dir
+- path: /allowed/directory/project_backup
   recursive: true
 ]`),
 		mcp.WithString("path",
@@ -209,9 +202,8 @@ demo_commands: [
 	deleteFileTool := mcp.NewTool("delete_file",
 		mcp.WithDescription(`description: Delete a file at the specified path. This permanently removes the file from the filesystem. Only works within allowed directories.
 demo_commands: [
-  path: /allowed/directory/temp.txt
-,
-  path: /allowed/directory/logs/old_log.txt
+- path: /allowed/directory/temp.txt
+- path: /allowed/directory/logs/old_log.txt
 ]`),
 		mcp.WithString("path",
 			mcp.Required(),
@@ -226,10 +218,9 @@ demo_commands: [
 	moveFileTool := mcp.NewTool("move_file",
 		mcp.WithDescription(`description: Move or rename a file from source_path to destination_path. This is equivalent to both moving a file to a different directory and renaming it in the same directory. Both paths must be within allowed directories.
 demo_commands: [
-  source_path: /allowed/directory/old_name.txt
+- source_path: /allowed/directory/old_name.txt
   destination_path: /allowed/directory/new_name.txt
-,
-  source_path: /allowed/directory/file.txt
+- source_path: /allowed/directory/file.txt
   destination_path: /allowed/directory/subfolder/file.txt
 ]`),
 		mcp.WithString("source_path",
@@ -249,10 +240,9 @@ demo_commands: [
 	copyFileTool := mcp.NewTool("copy_file",
 		mcp.WithDescription(`description: Copy a file from source_path to destination_path while keeping the original file intact. This creates a duplicate of the file at the new location. Both paths must be within allowed directories.
 demo_commands: [
-  source_path: /allowed/directory/template.html
+- source_path: /allowed/directory/template.html
   destination_path: /allowed/directory/pages/new_page.html
-,
-  source_path: /allowed/directory/config.json
+- source_path: /allowed/directory/config.json
   destination_path: /allowed/directory/config_backup.json
 ]`),
 		mcp.WithString("source_path",
@@ -272,11 +262,10 @@ demo_commands: [
 	searchFilesTool := mcp.NewTool("search_files",
 		mcp.WithDescription(`description: Search for text content within files in a directory. Returns matching files with line numbers and surrounding context for each match. Set recursive to true to search in all subdirectories recursively.
 demo_commands: [
-  query: function main
+- query: function main
   path: /allowed/directory/src
   recursive: true
-,
-  query: TODO
+- query: TODO
   path: /allowed/directory
   recursive: false
 ]`),
@@ -300,7 +289,7 @@ demo_commands: [
 	listAllowedDirectoriesTool := mcp.NewTool("list_allowed_directories",
 		mcp.WithDescription(`description: List all directories that are allowed to be accessed by the filesystem tools. This helps you understand which paths you can work with using the other tools. The response is a JSON array of directory paths.
 demo_commands: [
-  hi: ""
+- hi: ""
 ]`),
 		mcp.WithString("hi",
 			mcp.Description("no effect"),


### PR DESCRIPTION
- Convert tool descriptions to use multiline backtick strings for better readability - Add structured format with description and demo_commands sections - Include practical usage examples for each filesystem tool - Maintain all existing functionality while improving code maintainability