### PR TITLE
fix: skip empty files in search function

### DIFF
--- a/internal/tools/search_service.go
+++ b/internal/tools/search_service.go
@@ -104,6 +104,18 @@ func (s *SearchService) searchInFile(filePath, query string, results *[]SearchRe
 	}
 	defer file.Close()
 
+	// Check if the file is empty
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Skip empty files
+	if fileInfo.Size() == 0 {
+		s.logger.Debug("Skipping empty file: %s", filePath)
+		return nil
+	}
+
 	// Check if it's a binary file by reading the first few bytes
 	buf := make([]byte, 512)
 	n, err := file.Read(buf)

--- a/internal/tools/search_service_test.go
+++ b/internal/tools/search_service_test.go
@@ -155,6 +155,7 @@ func TestSearchService_searchInDirectory(t *testing.T) {
 	files := map[string]string{
 		filepath.Join(tmpDir, "file1.txt"):       "This is a test file with test content",
 		filepath.Join(tmpDir, "file2.txt"):       "Another file without the search term",
+		filepath.Join(tmpDir, "file3.txt"):       "",
 		filepath.Join(subDir, "nested-file.txt"): "Nested file with test content",
 	}
 


### PR DESCRIPTION
## Description
This PR adds an optimization to the `searchInFile` function by skipping empty files. The function now checks the file size immediately after opening it and returns early if the file is empty, avoiding unnecessary processing.

## Changes
- Added check for file size after opening it in the `searchInFile` function
- Added debug logging when skipping empty files, similar to the existing binary file logging

## Testing
- All existing tests pass
- Linting passes with no issues